### PR TITLE
Ignore Bundle-ClassPath entries that are not included in the bundle

### DIFF
--- a/p2-layout-resolver/src/main/java/org/openntf/maven/p2/layout/P2RepositoryLayout.java
+++ b/p2-layout-resolver/src/main/java/org/openntf/maven/p2/layout/P2RepositoryLayout.java
@@ -389,10 +389,10 @@ public class P2RepositoryLayout implements RepositoryLayout, Closeable {
 				try {
 					for(ManifestElement el : ManifestElement.parseHeader("Bundle-ClassPath", bundleClassPath)) { //$NON-NLS-1$
 						String cpName = el.getValue();
-						if(StringUtils.isEmpty(cpName) || ".".equals(cpName)) { //$NON-NLS-1$
+						if(StringUtils.isEmpty(cpName) || ".".equals(cpName) || !containsJarEntry(localJar, cpName)) { //$NON-NLS-1$
 							continue;
 						}
-						
+
 						if(cpName.toLowerCase().endsWith(".jar")) { //$NON-NLS-1$
 							cpName = cpName.substring(0, cpName.length()-4);
 						}
@@ -409,7 +409,16 @@ public class P2RepositoryLayout implements RepositoryLayout, Closeable {
 			}
 		}
 	}
-	
+
+	private boolean containsJarEntry(Path localJar, String fileName) {
+		try(ZipFile jarFile = new ZipFile(localJar.toFile())) {
+			ZipEntry classifiedEntry = jarFile.getEntry(fileName);
+			return classifiedEntry != null;
+		} catch (IOException e) {
+			throw new UncheckedIOException("Encountered exception reading local file " + localJar, e);
+		}
+	}
+
 	private Path getMetadata(Metadata metadata) {
 		return this.metadatas.computeIfAbsent(metadata.getArtifactId(), key -> {
 			Path metadataOut = this.metadataScratch.resolve("maven-metadata-" + metadata.getArtifactId() + ".xml"); //$NON-NLS-1$ //$NON-NLS-2$

--- a/p2-resolution.example/pom.xml
+++ b/p2-resolution.example/pom.xml
@@ -31,6 +31,11 @@
 			<url>https://download.eclipse.org/wildwebdeveloper/releases/0.8.0/</url>
 			<layout>p2</layout>
 		</repository>
+		<repository>
+			<id>org.eclipse.birt</id>
+			<url>https://download.eclipse.org/birt/updates/release/4.15.0</url>
+			<layout>p2</layout>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -48,6 +53,11 @@
 			<groupId>org.eclipse.wildwebdeveloper.p2.repo</groupId>
 			<artifactId>org.eclipse.wildwebdeveloper.xml</artifactId>
 			<version>[0.5.0,)</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.birt</groupId>
+			<artifactId>org.eclipse.birt.report.engine</artifactId>
+			<version>[4.15.0,)</version>
 		</dependency>
 		<dependency>
 			<groupId>io.quarkus.platform</groupId>

--- a/p2-resolution.example/src/main/java/com/example/UseClasses.java
+++ b/p2-resolution.example/src/main/java/com/example/UseClasses.java
@@ -4,6 +4,7 @@ public class UseClasses {
 	Class<?>[] classes = {
 		com.google.inject.multibindings.MapBinder.class,
 		org.apache.batik.css.dom.CSSOMComputedStyle.class,
-		org.eclipse.wildwebdeveloper.xml.XMLLanguageServer.class
+		org.eclipse.wildwebdeveloper.xml.XMLLanguageServer.class,
+		org.eclipse.birt.report.engine.api.EngineConfig.class
 	};
 }


### PR DESCRIPTION
Fix "Could not resolve dependencies" errors for some bundles in Eclipse Birt 4.15 p2 repository :

```
[ERROR] Failed to execute goal on project p2-resolution.example: Could not resolve dependencies for project com.example:p2-resolution.example:jar:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.eclipse.birt:org.eclipse.birt.report.model:jar:tests:4.15.0.v202403260939 (absent), org.eclipse.birt:org.eclipse.birt.report.model:jar:modelFragment_internal:4.15.0.v202403260939 (absent), org.eclipse.birt:org.eclipse.birt.data:jar:library:4.15.0.v202403260939 (absent), org.eclipse.birt:org.eclipse.birt.report.data.adapter:jar:library:4.15.0.v202403260939 (absent), org.eclipse.birt:org.eclipse.birt.report.engine:jar:enginetesthelper:4.15.0.v202403260939 (absent): Could not find artifact org.eclipse.birt:org.eclipse.birt.report.model:jar:tests:4.15.0.v202403260939 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```

May fix issue #30